### PR TITLE
Ensure project GitHub stats are updated on create or update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,9 @@ repos:
           - django-cotton
           - lucide
           - django-recaptcha
+          - django-solo
+          - httpx
+          - http_response_codes
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.

--- a/app/apps.py
+++ b/app/apps.py
@@ -1,6 +1,12 @@
-from django.apps import AppConfig as AC # to fix a mypy error
+from django.apps import AppConfig as AC  # to fix a mypy error
 
 
 class AppConfig(AC):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'app'
+    """Configure the Django app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "app"
+
+    def ready(self) -> None:
+        """Import signals when app is ready."""
+        import app.signals  # noqa: F401

--- a/app/signals.py
+++ b/app/signals.py
@@ -1,5 +1,6 @@
 """Configure Django signals."""
 
+# ruff: noqa: ARG001, ANN401
 from typing import Any
 
 from django.db.models.signals import post_save
@@ -11,11 +12,11 @@ from app.services.github import GitHubAPIService
 
 @receiver(post_save, sender=Project)
 def update_github_stats(
-    _sender: type[Project],
+    sender: type[Project],
     instance: Project,
     *,
-    _created: bool,
-    **_kwargs: Any,  # noqa: ANN401
+    created: bool,
+    **_kwargs: Any,
 ) -> None:
     """Update GitHub stats when a project is created or updated."""
     if instance.repo:  # Only proceed if the project has a GitHub repo URL

--- a/app/signals.py
+++ b/app/signals.py
@@ -1,0 +1,24 @@
+"""Configure Django signals."""
+
+from typing import Any
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from app.models import Project
+from app.services.github import GitHubAPIService
+
+
+@receiver(post_save, sender=Project)
+def update_github_stats(
+    _sender: type[Project],
+    instance: Project,
+    *,
+    _created: bool,
+    **_kwargs: Any,  # noqa: ANN401
+) -> None:
+    """Update GitHub stats when a project is created or updated."""
+    if instance.repo:  # Only proceed if the project has a GitHub repo URL
+        github_service = GitHubAPIService()
+        # Update stats synchronously for immediate feedback
+        github_service._update_stats_sync(instance)  # noqa: SLF001

--- a/config/settings.py
+++ b/config/settings.py
@@ -176,4 +176,4 @@ CACHES = {
     }
 }
 
-# SOLO_CACHE = "default"
+# SOLO_CACHE = "default"  # noqa: ERA001

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@ django==5.1.7
 django-browser-reload==1.18.0
 django-cotton==2.0.0
 django-recaptcha==4.0.0
+django-solo==2.4.0
 django-stubs==5.1.3
 django-stubs-ext==5.1.3
 django-tailwind==3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ certifi==2025.1.31
 django==5.1.7
 django-cotton==2.0.0
 django-recaptcha==4.0.0
+django-solo==2.4.0
 django-stubs-ext==5.1.3
 exceptiongroup==1.2.2 ; python_full_version < '3.11'
 h11==0.14.0


### PR DESCRIPTION
Previously when a new site was added all the stats were 0 until the next timeout where they were all updated. This fixes that so the stats are fetched whenever a new project is saved or existing project updated.