### PR TITLE
add a flag to enable/disable admin ip protection

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -12,6 +12,7 @@ DJANGO_POSTGRES_PORT=5432
 
 DJANGO_USE_CACHE=0 # 1 to use memcached and 0 to disable. Needs memcache installed
 DJANGO_CACHE_TIMEOUT=600 # set the cacahe timeout if it is used
+DJANGO_PROTECT_ADMIN=1 # set to 1 to enable IP-based admin access restriction, 0 to allow all IPs
 # IP addresses allowed to access admin panel. If not set, defaults to ["127.0.0.1", "localhost"]
 DJANGO_ADMIN_IPS_ALLOWED=["127.0.0.1", "192.168.1.100"]
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ have a default setting that will be used if not specified.
   for development) See the [Caching](#caching) secton below.
 - `DJANGO_CACHE_TIMEOUT`: Cache expiry length, in seconds (Defaults to 600, 10
   minutes)
+- `DJANGO_PROTECT_ADMIN`: Set to 1 to enable IP-based admin access restriction. If not set or set to 0, all IPs can access the admin panel
 - `DJANGO_ADMIN_IPS_ALLOWED`: JSON array of IP addresses allowed to access the
   admin panel, e.g. `["127.0.0.1", "192.168.1.100"]`. If not set, defaults to
-  `["127.0.0.1", "localhost"]`
+  `["127.0.0.1", "localhost"]`. Only used when `DJANGO_PROTECT_ADMIN` is set to 1
 
 > [!NOTE]
 >
@@ -193,6 +194,7 @@ DJANGO_STATIC_ROOT="/var/www/myproject/static/"
 
 DJANGO_USE_CACHE=0 # set to 0 for development, 1 for production when the database rarely changes
 DJANGO_CACHE_TIMEOUT=3600 # defaults to 600 (10 minutes) if not set
+DJANGO_PROTECT_ADMIN=1 # set to 1 to enable IP-based admin access restriction
 DJANGO_ADMIN_IPS_ALLOWED=["127.0.0.1", "192.168.1.100"] # IP addresses allowed to access admin panel
 
 RECAPTCHA_SITE_KEY=your-recaptcha-site-key
@@ -382,7 +384,8 @@ For production deployment, it's recommended to:
 2. Set `DJANGO_SECURE_MODE=1` to enable security features
 3. Use PostgreSQL instead of SQLite by setting `DJANGO_USE_POSTGRES=1` and
    configuring the related database settings
-4. Configure the production-specific environment variables:
+4. Set `DJANGO_PROTECT_ADMIN=1` to enable IP-based admin access restriction and configure `DJANGO_ADMIN_IPS_ALLOWED` with trusted IP addresses
+5. Configure the production-specific environment variables:
    - `DJANGO_CSRF_TRUSTED_ORIGINS`: Your domain(s) as a JSON array
    - `DJANGO_ALLOWED_HOSTS`: Your domain(s) as a JSON array
    - `DJANGO_STATIC_ROOT`: The path where static files will be collected
@@ -431,7 +434,7 @@ features are enabled:
 - Secure referrer policy
 - Permissions policy headers that restrict potentially dangerous browser
   features
-- IP-based admin access restriction - Only allows specified IP addresses to
+- IP-based admin access restriction - When `DJANGO_PROTECT_ADMIN=1`, only allows specified IP addresses to
   access the admin panel
 
 These features follow Django security best practices and help protect your

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,7 +46,7 @@ DJANGO_CSRF_TRUSTED_ORIGINS = json.loads(
     os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "[]")
 )
 DJANGO_ALLOWED_HOSTS = json.loads(os.getenv("DJANGO_ALLOWED_HOSTS", "[]"))
-
+DJANGO_PROTECT_ADMIN = bool(int(os.getenv("DJANGO_PROTECT_ADMIN", "0")))
 
 ALLOWED_HOSTS: list[str] = ["127.0.0.1", "localhost"]
 ALLOWED_HOSTS += DJANGO_ALLOWED_HOSTS
@@ -75,12 +75,14 @@ MIDDLEWARE = [
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "app.middleware.IPAdminRestrictMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
 ]
+
+if DJANGO_PROTECT_ADMIN:
+    MIDDLEWARE += ["app.middleware.IPAdminRestrictMiddleware"]
 
 if DEBUG:
     MIDDLEWARE += ["django_browser_reload.middleware.BrowserReloadMiddleware"]
@@ -271,6 +273,7 @@ if SECURE_MODE and not DEBUG:
     }
 
 # protect the admin route, only allow specific IP's to connect
+# Only used if `DJANGO_PROTECT_ADMIN=1` in the environment
 ADMIN_URL = "admin"
 ADMIN_IPS_ALLOWED = json.loads(
     os.getenv("DJANGO_ADMIN_IPS_ALLOWED", '["127.0.0.1","localhost"]')


### PR DESCRIPTION
The `DJANGO_PROTECT_ADMIN` env var can be set to `1` to enable protection the admin site by IP. If set to `0` (the default) it will not be protected.