### PR TITLE
add optional secure proxy settings.

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -16,6 +16,8 @@ DJANGO_PROTECT_ADMIN=1 # set to 1 to enable IP-based admin access restriction, 0
 # IP addresses allowed to access admin panel. If not set, defaults to ["127.0.0.1", "localhost"]
 DJANGO_ADMIN_IPS_ALLOWED=["127.0.0.1", "192.168.1.100"]
 
+DJANGO_SECURE_PROXY=0 # set to 1 if you are serving behind a secure proxy (ie nginx etc)
+
 DJANGO_CSRF_TRUSTED_ORIGINS=["https://www.myserver.com"]
 DJANGO_ALLOWED_HOSTS=[".myserver.com"]
 DJANGO_STATIC_ROOT="/var/www/myproject/static/"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ DJANGO_CACHE_TIMEOUT=3600 # defaults to 600 (10 minutes) if not set
 DJANGO_PROTECT_ADMIN=1 # set to 1 to enable IP-based admin access restriction
 DJANGO_ADMIN_IPS_ALLOWED=["127.0.0.1", "192.168.1.100"] # IP addresses allowed to access admin panel
 
+# enable secure proxy forwarding. This ALSO needs 'DJANGO_SECURE_MODE=1'
+DJANGO_SECURE_PROXY=0 # set to 1 if you are serving behind a secure proxy (ie nginx etc)
+
 # recaptcha settings
 RECAPTCHA_SITE_KEY=your-recaptcha-site-key
 RECAPTCHA_SECRET_KEY=your-recaptcha-secret-key
@@ -386,6 +389,15 @@ For production deployment, it's recommended to:
 
 1. Set `DJANGO_DEBUG=0` to disable debug mode
 2. Set `DJANGO_SECURE_MODE=1` to enable security features
+
+> [!Caution] Very Important
+>
+> The Secure Mode settings may need tweaking for your exact use-case. As it
+> stands, they work well for an application served behind an nginx reverse-proxy
+> (which is a GREAT way to serve your Django App) but may cause issues in other
+> cases. Checkout the `config/settings.py` file around the end to see what
+> settings are set and add/adjust any that you need for your specific setup.
+
 3. Use PostgreSQL instead of SQLite by setting `DJANGO_USE_POSTGRES=1` and
    configuring the related database settings
 4. Set `DJANGO_PROTECT_ADMIN=1` to enable IP-based admin access restriction and configure `DJANGO_ADMIN_IPS_ALLOWED` with trusted IP addresses

--- a/config/settings.py
+++ b/config/settings.py
@@ -51,6 +51,8 @@ DJANGO_PROTECT_ADMIN = bool(int(os.getenv("DJANGO_PROTECT_ADMIN", "0")))
 ALLOWED_HOSTS: list[str] = ["127.0.0.1", "localhost"]
 ALLOWED_HOSTS += DJANGO_ALLOWED_HOSTS
 
+SECURE_PROXY = bool(int(os.getenv("DJANGO_SECURE_PROXY", "0")))
+
 # Application definition
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -237,7 +239,9 @@ CACHE_MIDDLEWARE_KEY_PREFIX = ""
 if DJANGO_USE_CACHE:
     SOLO_CACHE = "default"
 
-# settings for PRODUCTION:
+# Settings for PRODUCTION.
+# IMPORTANT! These require your site to be served over https. DONT enable this
+# if it is not!!
 if SECURE_MODE and not DEBUG:
     SECURE_HSTS_SECONDS = (
         30  # Unit is seconds; *USE A SMALL VALUE FOR TESTING!*
@@ -245,7 +249,10 @@ if SECURE_MODE and not DEBUG:
     )
     SECURE_HSTS_PRELOAD = True
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+    if SECURE_PROXY:
+        SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+        USE_X_FORWARDED_HOST = True
 
     SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
     SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
This adds a `.env` or environment setting to allow better IP determination when using a proxy:

```ini
DJANGO_SECURE_PROXY=1
```

By default this is set to 0, and is ignored if `DEBUG=0` or `DJANGO_SECURE_MODE=0`
`
If set to 1, this will set the below 2 Django settings:

```ini
SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
USE_X_FORWARDED_HOST = True
```

This is really only needed if you are behind a reverse proxy (eg `nginx`) and are setting the `X_FORWARDED` header. It allows Django to to use the X-Forwarded-Host header in preference to the Host header. This should only be enabled if a proxy which sets this header is in use.