### PR TITLE
WIP add whitenoise to the stack for static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ backup.sqlite3
 .changelog_generator.toml
 prd
 .cursor
+static

--- a/config/settings.py
+++ b/config/settings.py
@@ -70,10 +70,14 @@ INSTALLED_APPS = [
 ]
 
 if DEBUG:
+    INSTALLED_APPS.insert(
+        0, "whitenoise.runserver_nostatic"
+    )  # Prevent Django from handling static, whitenoise will do it
     INSTALLED_APPS += ["django_browser_reload"]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -87,7 +91,9 @@ if DJANGO_PROTECT_ADMIN:
     MIDDLEWARE += ["app.middleware.IPAdminRestrictMiddleware"]
 
 if DEBUG:
+    MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
     MIDDLEWARE += ["django_browser_reload.middleware.BrowserReloadMiddleware"]
+
 
 if DJANGO_USE_CACHE:
     MIDDLEWARE = [
@@ -95,6 +101,7 @@ if DJANGO_USE_CACHE:
         *MIDDLEWARE,
         "django.middleware.cache.FetchFromCacheMiddleware",
     ]
+
 
 ROOT_URLCONF = "config.urls"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "psycopg[binary]>=3.2.6",
     "pymemcache>=4.0.0",
     "python-dotenv>=1.0.1",
+    "whitenoise>=6.9.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -274,6 +274,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pymemcache" },
     { name = "python-dotenv" },
+    { name = "whitenoise" },
 ]
 
 [package.dev-dependencies]
@@ -304,6 +305,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.6" },
     { name = "pymemcache", specifier = ">=4.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "whitenoise", specifier = ">=6.9.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1127,4 +1129,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/9c/57d19fa093bcf5ac61a48087dd44d00655f85421d1aa9722f8befbf3f40a/virtualenv-20.29.3.tar.gz", hash = "sha256:95e39403fcf3940ac45bc717597dba16110b74506131845d9b687d5e73d947ac", size = 4320280 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/eb/c6db6e3001d58c6a9e67c74bb7b4206767caa3ccc28c6b9eaf4c23fb4e34/virtualenv-20.29.3-py3-none-any.whl", hash = "sha256:3e3d00f5807e83b234dfb6122bf37cfadf4be216c53a49ac059d02414f819170", size = 4301458 },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/cf/c15c2f21aee6b22a9f6fc9be3f7e477e2442ec22848273db7f4eb73d6162/whitenoise-6.9.0.tar.gz", hash = "sha256:8c4a7c9d384694990c26f3047e118c691557481d624f069b7f7752a2f735d609", size = 25920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b2/2ce9263149fbde9701d352bda24ea1362c154e196d2fda2201f18fc585d7/whitenoise-6.9.0-py3-none-any.whl", hash = "sha256:c8a489049b7ee9889617bb4c274a153f3d979e8f51d2efd0f5b403caf41c57df", size = 20161 },
 ]


### PR DESCRIPTION
This is a work in progress PR to add `whitenoise` to serve the static files. It may not get any more progress.

At the moment I use nginx to serve the static and this will prob not change, but `whitenoise` does allow to server static files with `runserver` when `DEBUG=0` so useful for development.