### PR TITLE
ensure correct js file is added to context for all views

### DIFF
--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -1,0 +1,9 @@
+"""Define some context processors."""
+
+from django.conf import settings
+from django.http import HttpRequest
+
+
+def add_correct_javascript(request: HttpRequest) -> dict[str, str]:  # noqa: ARG001
+    """Adds the correct javascript file to context depending on DEBUG or not."""
+    return {"js_file": "js/site.js" if settings.DEBUG else "js/site.min.js"}

--- a/app/views.py
+++ b/app/views.py
@@ -3,7 +3,6 @@
 # ruff: noqa: ANN401
 from typing import Any
 
-from django.conf import settings
 from django.contrib import messages
 from django.db import models
 from django.db.models import Case, F, Value, When
@@ -97,11 +96,6 @@ class ProjectsListView(ListView[Project]):
         for section in about_sections:
             section.content = sanitizer.sanitize(section.content)
         context["about_sections"] = about_sections
-
-        # Add js file name based on debug mode
-        context["js_file"] = (
-            "js/site.js" if settings.DEBUG else "js/site.min.js"
-        )
 
         return context
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -117,6 +117,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "app.context_processors.add_correct_javascript",
             ],
         },
     },


### PR DESCRIPTION
the 'js_file' context was missing from the error pages, so the theme and changer did not work. 

this is added as a context processor to save adding to all the different error views.