### PR TITLE
Add a noscript block and fix some issues with theme dropdown

### DIFF
--- a/templates/app/base.html
+++ b/templates/app/base.html
@@ -33,6 +33,9 @@
         color: #d8000c;
         text-align: center;
         border-bottom: 1px solid #fcc;
+        position: sticky;
+        top: 0;
+        z-index: 50;
       }
 
     </style>

--- a/templates/app/base.html
+++ b/templates/app/base.html
@@ -6,7 +6,7 @@
 {% get_solo 'app.SiteConfiguration' as config %}
 
 <!DOCTYPE html>
-<html lang="en" class="dark:bg-gray-900">
+<html lang="en" class="no-js dark:bg-gray-900">
 
   <head>
     <meta charset="UTF-8">
@@ -20,6 +20,22 @@
     <link media="screen"
       href="https://fonts.googleapis.com/css2?family=Birthstone:wght@300;400;500;600;700&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
       rel="stylesheet">
+    <script>document.documentElement.classList.remove('no-js');</script>
+    <style>
+      #js-warning {
+        display: none;
+      }
+
+      html.no-js body #js-warning {
+        display: block;
+        padding: 1rem;
+        background-color: #ffdddd;
+        color: #d8000c;
+        text-align: center;
+        border-bottom: 1px solid #fcc;
+      }
+
+    </style>
     <script defer src="{% static js_file %}"></script>
     <script defer src="https://unpkg.com/htmx.org@1.9.10"></script>
     <script defer
@@ -28,6 +44,10 @@
   </head>
 
   <body class="bg-background text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div id="js-warning">
+      <strong>JavaScript is disabled or blocked.</strong> Some features of this
+      site may not work correctly.
+    </div>
     {% include "app/_header.html" %}
     <main class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pb-4" id="main-content">
       {% if messages %}

--- a/templates/cotton/dropdown_menu/content.html
+++ b/templates/cotton/dropdown_menu/content.html
@@ -1,4 +1,5 @@
-<div x-show="open" @click.away="open = false" class="
+<div x-show="open" @click.away="open = false" style="display: none;"
+  x-init="$el.style.display = ''" class="
     absolute
     z-50
     min-w-32

--- a/templates/cotton/dropdown_menu/trigger.html
+++ b/templates/cotton/dropdown_menu/trigger.html
@@ -1,4 +1,5 @@
-<div @click="open = !open"
+<div @click="open = !open" style="display: none;"
+    x-init="$el.style.display = ''"
     class="outline-hidden {% if class %}{{ class }}{% endif %}" {{ attrs }}>
     {{ slot }}
 </div>


### PR DESCRIPTION
- add a no-script banner at the top if JavaScript is disabled.
- stop the brief flashing of the theme menu and buttons when the page first loads
- stop the drop-down being displayed but unusable if JavaScript is disabled.