### PR TITLE
fix custom error pages (bad base template path)

### DIFF
--- a/templates/400.html
+++ b/templates/400.html
@@ -1,4 +1,4 @@
-{% extends "app/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="flex items-center justify-center py-12">

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,4 +1,4 @@
-{% extends "app/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="flex items-center justify-center py-12">

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,4 +1,4 @@
-{% extends "app/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="flex items-center justify-center py-12">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,4 +1,4 @@
-{% extends "app/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="flex items-center justify-center py-12">


### PR DESCRIPTION
When the `base.html` template was moved to the template root, the custom 404 etc templates were still pointing to the old location and so they failed. 